### PR TITLE
Add windows-based CI tool

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  # matrix:
+  # - nodejs_version: "0.8"
+  # - nodejs_version: "0.10"
+  # - nodejs_version: "0.12"
+  nodejs_version: "0.10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
 environment:
-  # matrix:
-  # - nodejs_version: "0.8"
-  # - nodejs_version: "0.10"
-  # - nodejs_version: "0.12"
-  nodejs_version: "0.10"
+  matrix:
+  - nodejs_version: "0.8"
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
   webp_version: "0.4.3"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,15 @@ environment:
   # - nodejs_version: "0.10"
   # - nodejs_version: "0.12"
   nodejs_version: "0.10"
+  webp_version: "0.4.3"
 
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
+  - ps: .\bin\download_webp.ps1
 
 test_script:
+  - cwebp -version
   - node --version
   - npm --version
   - npm test

--- a/src/wrapper.coffee
+++ b/src/wrapper.coffee
@@ -22,7 +22,8 @@ module.exports = class Wrapper
       'pipe' # stderr
     ]
     proc = spawn @bin, args, {stdio}
-    proc.once 'error', reject
+    proc.once 'error', (err) ->
+      reject err unless err.code is 'OK' is err.errno
     proc.once 'close', onClose = (code, signal) ->
       if code isnt 0 or signal isnt null
         err = new Error "Command failed: #{stderr}"

--- a/test/cwebp.coffee
+++ b/test/cwebp.coffee
@@ -1,4 +1,5 @@
 fs = require 'fs'
+os = require 'os'
 
 {CWebp} = require '../src'
 data = require './utils/data'
@@ -19,25 +20,17 @@ describe 'cwebp', ->
         buffer.toString('utf8', 0, 4).should.be.equal 'RIFF'
         buffer.toString('utf8', 8, 12).should.be.equal 'WEBP'
 
-    it 'should report verbose errors', ->
+    it 'should report errors', ->
       webp = new CWebp data.corrupt
-      webp.verbose().toBuffer().then ->
-        throw new Error 'Should not be fulfilled'
-      , (err) ->
-        err.should.be.Error
-        err.message.should.match /Premature end of JPEG file/
-        err.message.should.match /JPEG datastream contains no image/
-
-    it 'should allow default verbose rewriting', ->
-      class Webp3 extends CWebp
-        @verbose: true
-      webp = new Webp3 data.corrupt
       webp.toBuffer().then ->
         throw new Error 'Should not be fulfilled'
       , (err) ->
         err.should.be.Error
-        err.message.should.match /Premature end of JPEG file/
-        err.message.should.match /JPEG datastream contains no image/
+        if os.platform() is 'linux'
+          err.message.should.match /Premature end of JPEG file/
+          err.message.should.match /JPEG datastream contains no image/
+        err.message.should.match /Error! Could not process file/
+        err.message.should.match /Error! Cannot read input picture file/
 
     it 'should cleanup tmp files on error', ->
       filename = ''


### PR DESCRIPTION
In order to catch windows-specific bugs we should configure a windows-backed CI tool to work along with ubuntu-backed Travis CI.

Currently, the best candidate is [AppVeyor][1].

References:

 * [AppVeyor integration docs for node.js/io.js projects][2].

  [1]: https://ci.appveyor.com/
  [2]: http://www.appveyor.com/docs/lang/nodejs-iojs