### PR TITLE
Fix link to methods.json from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ encoder.quality(60);
 decoder.tiff();
 ```
 
-  [methods]: https://github.com/Intervox/node-webp/blob/latest/src/methods.json
+  [methods]: https://github.com/Intervox/node-webp/blob/latest/methods.json
 
 #### Sending raw command
 


### PR DESCRIPTION
e0570f834a7284b9a0e701a5ae0ab4616aeb2e8b moved the methods.json file from src to root, but this wasn't updated in the readme.